### PR TITLE
feat(examples): Introduce Skipper as example

### DIFF
--- a/examples/skipper-0.18/.gitignore
+++ b/examples/skipper-0.18/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/skipper-0.18/Dockerfile
+++ b/examples/skipper-0.18/Dockerfile
@@ -1,0 +1,23 @@
+FROM --platform=linux/x86_64 golang:1.21.4-bookworm AS build
+
+RUN set -xe; apt-get update ; \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      git \
+      unzip \
+      ;
+
+WORKDIR /
+
+RUN set -xe; \
+    wget -O skipper.zip "https://github.com/zalando/skipper/archive/refs/tags/v0.18.51.zip"; \
+    unzip -q skipper.zip;
+
+WORKDIR /skipper-0.18.51
+
+RUN CGO_ENABLED=1 go build -buildmode=pie -ldflags "-linkmode external -extldflags '-static-pie'" -o /usr/local/bin/skipper ./cmd/skipper
+
+FROM scratch
+
+COPY --from=build /usr/local/bin/skipper /usr/local/bin/skipper
+COPY example.eskip /etc/skipper/example.eskip

--- a/examples/skipper-0.18/Kraftfile
+++ b/examples/skipper-0.18/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: skipper
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/skipper", "-routes-file", "/etc/skipper/example.eskip"]

--- a/examples/skipper-0.18/Makefile
+++ b/examples/skipper-0.18/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-skipper
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/skipper-0.18/README.md
+++ b/examples/skipper-0.18/README.md
@@ -1,0 +1,35 @@
+# Skipper 0.18
+
+This directory contains the definition to run [Skipper](https://github.com/zalando/skipper) on Unikraft in binary compatibility mode.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 512M -p 9090:9090
+```
+
+Once executed, it will open port `9090` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:9090/hello
+```
+
+This doesn't work, however, probably due to some Skipper specifics.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:9090/hello
+```
+
+This will show a `Hello, World!` message, provided by the Skipper proxy.
+It means Skipper was started successfully.

--- a/examples/skipper-0.18/config.yaml
+++ b/examples/skipper-0.18/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 512

--- a/examples/skipper-0.18/example.eskip
+++ b/examples/skipper-0.18/example.eskip
@@ -1,0 +1,22 @@
+hello:
+        Path("/hello")
+        -> status(200)
+        -> inlineContent("Hello, World!")
+        -> <shunt>;
+
+null:
+        Path("/null")
+        -> "http://172.32.255.1/null";
+
+gold:
+        Path("/gold")
+        -> "http://172.32.255.1/gold";
+
+oneb:
+        Path("/1b")
+        -> "http://172.32.255.1/1b";
+
+rest: *
+        -> status(404)
+        -> inlineContent("No route entry")
+        -> <shunt>;


### PR DESCRIPTION
Add Skipper as binary compatibility run. Build Skipper as static PIE application using `Dockerfile`. Then run it with the base image from the registry.