### PR TITLE
feat(utils): Add script to start BuildKit container

### DIFF
--- a/utils/start-buildkit.sh
+++ b/utils/start-buildkit.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export KRAFTKIT_BUILDKIT_HOST=docker-container://buildkitd
+docker container inspect buildkitd > /dev/null 2>&1 || docker run -d --name buildkitd --privileged moby/buildkit:latest


### PR DESCRIPTION
Add script to start and setup the BuildKit container. This is required for Dockerfile root filesystems present in the Kraftfile.