### PR TITLE
feat(examples): Introduce sqld as example

### DIFF
--- a/examples/sqld-0.21/.gitignore
+++ b/examples/sqld-0.21/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/sqld-0.21/Dockerfile
+++ b/examples/sqld-0.21/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=linux/x86_64 ghcr.io/libsql/sqld:v0.21.9 AS build
+
+FROM scratch
+
+# Copy executable.
+COPY --from=build /bin/sqld /usr/local/bin/sqld
+
+# Copy libraries.
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/examples/sqld-0.21/Kraftfile
+++ b/examples/sqld-0.21/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: sqld
+
+runtime: index.unikraft.io/unikraft.org/base
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/sqld", "--http-listen-addr", "0.0.0.0:8080"]

--- a/examples/sqld-0.21/Makefile
+++ b/examples/sqld-0.21/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-sqld
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/sqld-0.21/README.md
+++ b/examples/sqld-0.21/README.md
@@ -1,0 +1,23 @@
+# sqld
+
+This directory contains the definition to run [sqld](https://github.com/tursodatabase/libsql/tree/main/libsql-server) on Unikraft in binary compatibility mode.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+**Note**: Currently, Unikraft sqld runs don't work due to lack of UNIX socket support.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 256M -p 8080:8080
+```
+
+This starts an SQL server waiting for HTTP connection on port `8080`.
+You can use [client libraries](https://github.com/tursodatabase/libsql/blob/main/docs/BUILD-RUN.md#query-sqld) to query it.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+They will starts an SQL server waiting for HTTP connection on port `8080`.

--- a/examples/sqld-0.21/config.yaml
+++ b/examples/sqld-0.21/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 256


### PR DESCRIPTION
Introduce sqld as binary compatibility run. Use pre-built version of sqld using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.
