### PR TITLE
feat(examples): Introduce Wasmtime Rust Hello

### DIFF
--- a/examples/hello-wasmtime-rust/.gitignore
+++ b/examples/hello-wasmtime-rust/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/hello-wasmtime-rust/Dockerfile
+++ b/examples/hello-wasmtime-rust/Dockerfile
@@ -1,0 +1,41 @@
+FROM --platform=linux/x86_64 debian:bookworm AS wasmtime
+
+ARG WASMTIME_VERSION=14.0.4
+
+WORKDIR /wasmtime
+
+RUN set -xe; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      wget \
+      xz-utils; \
+    wget https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz; \
+    tar xvf wasmtime-v${WASMTIME_VERSION}-x86_64-linux.tar.xz; \
+    mv wasmtime-v${WASMTIME_VERSION}-x86_64-linux/wasmtime /usr/local/bin; \
+    rm -rf wasmtime-v${WASMTIME_VERSION}-x86_64-linux* \
+    ;
+
+FROM --platform=linux/x86_64 rust:1.73.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./hello.rs /src/hello.rs
+
+RUN set -xe; \
+    rustup target add wasm32-wasi; \
+    rustc --target wasm32-wasi \
+      -o /hello.wasm /src/hello.rs \
+    ;
+
+FROM scratch
+
+COPY --from=build /hello.wasm /hello.wasm
+COPY --from=wasmtime /usr/local/bin/wasmtime /usr/local/bin/wasmtime
+COPY --from=wasmtime /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2 
+COPY --from=wasmtime /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1 
+COPY --from=wasmtime /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1 
+COPY --from=wasmtime /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0 
+COPY --from=wasmtime /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6 
+COPY --from=wasmtime /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6 
+COPY --from=wasmtime /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 

--- a/examples/hello-wasmtime-rust/Kraftfile
+++ b/examples/hello-wasmtime-rust/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: hello-wasmtime-rust
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/wasmtime", "/hello.wasm"]

--- a/examples/hello-wasmtime-rust/Makefile
+++ b/examples/hello-wasmtime-rust/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-wasmtime-rust
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/hello-wasmtime-rust/README.md
+++ b/examples/hello-wasmtime-rust/README.md
@@ -1,0 +1,21 @@
+# Wasmtime Hello Rust
+
+This directory contains the definition to run a helloworld Rust program with [Wasmtime](https://github.com/bytecodealliance/wasmtime) on Unikraft in binary compatibility mode.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 256M
+```
+
+Once executed, it will start Wasmtime in binary compatibility mode.
+Wasmtime will run the `hello.wasm` binary generated from the `hello.rs` program.
+The result will be the printing of a `Hello, World!` message.
+
+## Scripted Run
+
+You can also use the scripted runs, detailed in the common `../README.md`.

--- a/examples/hello-wasmtime-rust/config.yaml
+++ b/examples/hello-wasmtime-rust/config.yaml
@@ -1,0 +1,3 @@
+networking: False
+accel: True
+memory: 256

--- a/examples/hello-wasmtime-rust/hello.rs
+++ b/examples/hello-wasmtime-rust/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+        println!("Hello, world!");
+}


### PR DESCRIPTION
Introduce Wasmtime as binary compatibility run. Run a Helloworld Rust-based program. Extract Wasm time using `Dockerfile`. Then run it ith the `base` kernel images from `../../kernels/`.
    
Add typical files for a bincompat app:
    
* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `hello.rs`: the helloworld Rust program to be built into a WASM binary
    
`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.
    
The kernels in `../../kernels` are generated by running the  `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.
