### PR TITLE
    feat(examples): Introduce HTTP C server as example

### DIFF
--- a/examples/http-c-bin/.gitignore
+++ b/examples/http-c-bin/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-c-bin/Dockerfile
+++ b/examples/http-c-bin/Dockerfile
@@ -1,0 +1,16 @@
+FROM --platform=linux/x86_64 gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.c /src/http_server.c
+
+RUN set -xe; \
+    gcc -Wall -Wextra -fPIC -pie \
+        -o /http_server http_server.c \
+    ;
+
+FROM scratch
+
+COPY --from=build /http_server /http_server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6 
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 

--- a/examples/http-c-bin/Kraftfile
+++ b/examples/http-c-bin/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-c
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/http-c-bin/Makefile
+++ b/examples/http-c-bin/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-http-c
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-c-bin/README.md
+++ b/examples/http-c-bin/README.md
@@ -1,0 +1,33 @@
+# Simple HTTP C Server on Unikraft
+
+This directory contains a simple HTTP server written in C running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 128M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-c-bin/config.yaml
+++ b/examples/http-c-bin/config.yaml
@@ -1,0 +1,4 @@
+networking: True
+accel: True
+memory: 128
+kerneldir: ../../kernels

--- a/examples/http-c-bin/http_server.c
+++ b/examples/http-c-bin/http_server.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+static const char reply[] = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 14\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Hello, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		fprintf(stderr, "Failed to create socket: %d\n", errno);
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		fprintf(stderr, "Failed to bind socket: %d\n", errno);
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		fprintf(stderr, "Failed to listen on socket: %d\n", errno);
+		goto out;
+	}
+
+	printf("Listening on port %d...\n", LISTEN_PORT);
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			fprintf(stderr,
+				"Failed to accept incoming connection: %d\n",
+				errno);
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply, sizeof(reply) - 1);
+		if (n < 0)
+			fprintf(stderr, "Failed to send a reply\n");
+		else
+			printf("Sent a reply\n");
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
Introduce an HTTP C server as binary compatibility run. Build server as a PIE application using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.c`: the C HTTP server
    
`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.
