### PR TITLE
feat(examples): Introduce HTTP Rust server as example

### DIFF
--- a/examples/http-rust1.73/.gitignore
+++ b/examples/http-rust1.73/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-rust1.73/Dockerfile
+++ b/examples/http-rust1.73/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=linux/x86_64 rust:1.73.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.rs /src/http_server.rs
+
+RUN set -xe; \
+    rustc -o /http_server /src/http_server.rs
+
+FROM scratch
+
+COPY --from=build /http_server /http_server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/examples/http-rust1.73/Kraftfile
+++ b/examples/http-rust1.73/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-rust
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/http-rust1.73/Makefile
+++ b/examples/http-rust1.73/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-rust
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-rust1.73/README.md
+++ b/examples/http-rust1.73/README.md
@@ -1,0 +1,33 @@
+# Simple HTTP Rust Server on Unikraft
+
+This directory contains a simple HTTP server written in Rust running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 128M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-rust1.73/config.yaml
+++ b/examples/http-rust1.73/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 512

--- a/examples/http-rust1.73/http_server.rs
+++ b/examples/http-rust1.73/http_server.rs
@@ -1,0 +1,50 @@
+// https://gist.github.com/mjohnsullivan/e5182707caf0a9dbdf2d
+// Updated example from http://rosettacode.org/wiki/Hello_world/Web_server#Rust
+// to work with Rust 1.0 beta
+
+use std::net::{TcpStream, TcpListener};
+use std::io::{Read, Write};
+use std::thread;
+
+
+fn handle_read(mut stream: &TcpStream) {
+    let mut buf = [0u8 ;4096];
+    match stream.read(&mut buf) {
+        Ok(_) => {
+            let req_str = String::from_utf8_lossy(&buf);
+            println!("{}", req_str);
+        },
+        Err(e) => println!("Unable to read stream: {}", e),
+    }
+}
+
+fn handle_write(mut stream: TcpStream) {
+    let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n<html><body>Hello, World!</body></html>\r\n";
+    match stream.write(response) {
+        Ok(_) => println!("Response sent"),
+        Err(e) => println!("Failed sending response: {}", e),
+    }
+}
+
+fn handle_client(stream: TcpStream) {
+    handle_read(&stream);
+    handle_write(stream);
+}
+
+fn main() {
+    let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
+    println!("Listening for connections on port {}", 8080);
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                thread::spawn(|| {
+                    handle_client(stream)
+                });
+            }
+            Err(e) => {
+                println!("Unable to connect: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce an HTTP Rust server as binary compatibility run. Build server as a PIE application using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.rs`: the Rust HTTP server

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.