### PR TITLE
feat(examples): Introduce HTTP Go server as example

### DIFF
--- a/examples/http-go1.21/.gitignore
+++ b/examples/http-go1.21/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-go1.21/Dockerfile
+++ b/examples/http-go1.21/Dockerfile
@@ -1,0 +1,19 @@
+FROM --platform=linux/x86_64 golang:1.21.3-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.go /src/http_server.go
+
+RUN set -xe; \
+    go build \
+      -buildmode=pie \
+      -ldflags "-linkmode external -extldflags -static-pie" \
+      -tags netgo \
+      -o /http_server http_server.go \
+    ;
+
+FROM scratch
+
+COPY --from=build /http_server /http_server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/examples/http-go1.21/Kraftfile
+++ b/examples/http-go1.21/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-go
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/http-go1.21/Makefile
+++ b/examples/http-go1.21/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-go
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-go1.21/README.md
+++ b/examples/http-go1.21/README.md
@@ -1,0 +1,33 @@
+# Simple HTTP C Server on Unikraft
+
+This directory contains a simple HTTP server written in Go running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 512M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-go1.21/config.yaml
+++ b/examples/http-go1.21/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 512

--- a/examples/http-go1.21/http_server.go
+++ b/examples/http-go1.21/http_server.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func hello(w http.ResponseWriter, req *http.Request) {
+	fmt.Fprintf(w, "hello, world!\n")
+}
+
+func main() {
+	http.HandleFunc("/", hello)
+	fmt.Println("Listening on :8080...")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Introduce an HTTP Go server as binary compatibility run. Build server as a PIE application using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.go`: the Go HTTP server

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.