### PR TITLE
feat(examples): Introduce HTTP C++ server as example

### DIFF
--- a/examples/http-cpp-bin/.gitignore
+++ b/examples/http-cpp-bin/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-cpp-bin/Dockerfile
+++ b/examples/http-cpp-bin/Dockerfile
@@ -1,0 +1,21 @@
+FROM --platform=linux/x86_64 gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+    g++ -Wall -Wextra -fPIC -pie \
+        -o /http_server http_server.cpp
+
+FROM scratch
+
+# System / C++ libraries
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /usr/local/lib64/libgcc_s.so.1 /usr/local/lib64/libgcc_s.so.1
+COPY --from=build /usr/local/lib64/libstdc++.so.6 /usr/local/lib64/libstdc++.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server

--- a/examples/http-cpp-bin/Kraftfile
+++ b/examples/http-cpp-bin/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-cpp-bin
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/http-cpp-bin/Makefile
+++ b/examples/http-cpp-bin/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-http-cpp
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-cpp-bin/README.md
+++ b/examples/http-cpp-bin/README.md
@@ -1,0 +1,33 @@
+# Simple HTTP C++ Server on Unikraft
+
+This directory contains a simple HTTP server written in C++ running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 128M -p 8008:8080
+```
+
+Once executed, it will open port `8008` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-cpp-bin/config.yaml
+++ b/examples/http-cpp-bin/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 128

--- a/examples/http-cpp-bin/http_server.cpp
+++ b/examples/http-cpp-bin/http_server.cpp
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <iostream>
+#include <cstring>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+
+static std::string reply = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 14\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Hello, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		std::cerr << "Failed to create socket: " << errno << std::endl;
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		std::cerr << "Failed to bind socket: " << errno << std::endl;
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		std::cerr << "Failed to listen on socket: " << errno << std::endl;
+		goto out;
+	}
+
+	std::cout << "Listening on port " << LISTEN_PORT << std::endl;
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			std::cerr << "Failed to accept incoming connection: " << errno << std::endl;
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply.c_str(), reply.length());
+		if (n < 0)
+			std::cerr << "Failed to send reply" << std::endl;
+		else
+			std::cout << "Sent a reply" << std::endl;
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
Introduce an HTTP C++ server as binary compatibility run. Build server as static PIE application using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.cpp`: the C++ HTTP server

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.