### PR TITLE
feat(examples): Introduce HTTP Node server as example

### DIFF
--- a/examples/http-node18/.gitignore
+++ b/examples/http-node18/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-node18/Dockerfile
+++ b/examples/http-node18/Dockerfile
@@ -1,0 +1,44 @@
+FROM --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe ; \
+    apt -yqq update ; \
+    apt -yqq install nodejs \
+    ;
+
+FROM scratch
+
+# Node binary
+COPY --from=build /usr/bin/node /usr/local/bin/node
+
+# Node files
+COPY --from=build /usr/share/nodejs /usr/share/nodejs
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libnode.so.108 /lib/x86_64-linux-gnu/libnode.so.108
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libuv.so.1 /lib/x86_64-linux-gnu/libuv.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlidec.so.1 /lib/x86_64-linux-gnu/libbrotlidec.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlienc.so.1 /lib/x86_64-linux-gnu/libbrotlienc.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libcares.so.2 /lib/x86_64-linux-gnu/libcares.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libnghttp2.so.14 /lib/x86_64-linux-gnu/libnghttp2.so.14
+COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libicui18n.so.72 /lib/x86_64-linux-gnu/libicui18n.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libicuuc.so.72 /lib/x86_64-linux-gnu/libicuuc.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlicommon.so.1 /lib/x86_64-linux-gnu/libbrotlicommon.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libicudata.so.72 /lib/x86_64-linux-gnu/libicudata.so.72
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# Distro definition
+COPY --from=build /etc/os-release /etc/os-release
+COPY --from=build /usr/lib/os-release /usr/lib/os-release
+
+# Node HTTP server
+COPY ./http_server.js /http_server.js

--- a/examples/http-node18/Kraftfile
+++ b/examples/http-node18/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-node
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/node", "/http_server.js"]

--- a/examples/http-node18/Makefile
+++ b/examples/http-node18/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-node
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-node18/README.md
+++ b/examples/http-node18/README.md
@@ -1,0 +1,33 @@
+# Simple Node HTTP Web Server
+
+This directory contains a simple HTTP server written in JavaScript for [Node](https://nodejs.org/en/) running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 512M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-node18/config.yaml
+++ b/examples/http-node18/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 512

--- a/examples/http-node18/http_server.js
+++ b/examples/http-node18/http_server.js
@@ -1,0 +1,16 @@
+const http = require('http'); // Loads the http module
+
+http.createServer((request, response) => {
+
+    // 1. Tell the browser everything is OK (Status code 200), and the data is in plain text
+    response.writeHead(200, {
+        'Content-Type': 'text/plain'
+    });
+
+    // 2. Write the announced text to the body of the page
+    response.write('Hello, World!\n');
+
+    // 3. Tell the server that all of the response headers and body have been sent
+    response.end();
+
+}).listen(8080); // 4. Tells the server what port to be on


### PR DESCRIPTION
Introduce an HTTP Node server as binary compatibility run. Install Node using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.js`: HTTP server implementation in Node

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.