### PR TITLE
feat(examples): Introduce DuckDB CLI as example

### DIFF
--- a/examples/duckdb-0.9-cli/.gitignore
+++ b/examples/duckdb-0.9-cli/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/duckdb-0.9-cli/Dockerfile
+++ b/examples/duckdb-0.9-cli/Dockerfile
@@ -1,0 +1,43 @@
+FROM --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe; \
+    apt -yqq update; \
+    apt -yqq install \
+        wget \
+        ca-certificates \
+        build-essential \
+        git \
+        cmake \
+        ninja-build \
+        unzip \
+    ;
+
+ARG DUCKDB_VERSION=0.9.2
+
+WORKDIR /src
+
+RUN set -xe; \
+    wget https://github.com/duckdb/duckdb/archive/refs/tags/v${DUCKDB_VERSION}.zip; \
+    unzip -q v${DUCKDB_VERSION}.zip \
+    ;
+
+WORKDIR /src/duckdb-${DUCKDB_VERSION}
+
+RUN set -xe; \
+    GEN=ninja make \
+    ;
+
+FROM scratch
+
+# DuckDB CLI binary
+COPY --from=build /src/duckdb-0.9.2/build/release/duckdb /usr/local/bin/duckdb
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# Test file
+COPY ./test.sql /test.sql

--- a/examples/duckdb-0.9-cli/Kraftfile
+++ b/examples/duckdb-0.9-cli/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: duckdb-cli
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/duckdb", "-init", "/test.sql", "-no-stdin"]

--- a/examples/duckdb-0.9-cli/Makefile
+++ b/examples/duckdb-0.9-cli/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-duckdb-cli
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/duckdb-0.9-cli/README.md
+++ b/examples/duckdb-0.9-cli/README.md
@@ -1,0 +1,33 @@
+# DuckDB CLI Example
+
+This directory contains the [DuckDB](https://duckdb.org) CLI running with Unikraft in binary compatibility mode.
+The CLI is [built from source](https://duckdb.org/dev/building.html) via `Dockerfile` as a PIE binary.
+This is because [the release version](https://duckdb.org/docs/installation/index?version=latest&environment=cli&installer=binary&platform=linux) is not PIE.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 128M
+```
+
+Once executed, it will run the script in `test.sql`, resulting in the printing of an SQL query result:
+
+```console
+-- Loading resources from /test.sql
+-----------------
+|  age  | grade |
+| int32 | int32 |
++-------|-------+
+|    20 |    10 |
+|    21 |     9 |
++---------------+
+```
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Running the scripts will print out information ame as above.

--- a/examples/duckdb-0.9-cli/config.yaml
+++ b/examples/duckdb-0.9-cli/config.yaml
@@ -1,0 +1,3 @@
+networking: False
+accel: True
+memory: 256

--- a/examples/duckdb-0.9-cli/test.sql
+++ b/examples/duckdb-0.9-cli/test.sql
@@ -1,0 +1,9 @@
+CREATE TABLE students (
+	age INT,
+	grade INT,
+);
+
+INSERT INTO students(age, grade) VALUES(20, 10);
+INSERT INTO students(age, grade) VALUES(21, 9);
+
+SELECT * FROM students;


### PR DESCRIPTION
Introduce DuckDB CLI as binary compatibility run. Build DuckDB as PIE application using `Dockerfile` - it takes about 10-20 minutes; the default binary provided by DuckDB is not PIE. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `test.sql`: SQL test file

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.
