### PR TITLE
feat(examples): Introduce HTTP C++ Boost server as example

### DIFF
--- a/examples/http-boost1.74/.gitignore
+++ b/examples/http-boost1.74/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-boost1.74/Dockerfile
+++ b/examples/http-boost1.74/Dockerfile
@@ -1,0 +1,30 @@
+FROM --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe ; \
+	apt -yqq update ; \
+	apt -yqq install build-essential ; \
+	apt -yqq install libboost-all-dev
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+    g++ \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.cpp \
+	-lboost_system -lboost_thread -lpthread
+
+FROM scratch
+
+# System / C++ libraries
+COPY --from=build /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0 /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server

--- a/examples/http-boost1.74/Kraftfile
+++ b/examples/http-boost1.74/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-boost
+
+runtime: index.unikraft.io/official/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/examples/http-boost1.74/Makefile
+++ b/examples/http-boost1.74/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-boost
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-boost1.74/README.md
+++ b/examples/http-boost1.74/README.md
@@ -1,0 +1,33 @@
+# Simple HTTP C++ Boost Server on Unikraft
+
+This directory contains a simple HTTP server written in C++ Boost running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 128M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-boost1.74/config.yaml
+++ b/examples/http-boost1.74/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 256

--- a/examples/http-boost1.74/http_server.cpp
+++ b/examples/http-boost1.74/http_server.cpp
@@ -1,0 +1,114 @@
+/**
+ *  Compile with: g++ async_http_server.cpp -o async_http_server -lboost_system -lboost_thread -lpthread
+ *
+ *  https://gist.github.com/danilogr/990efa4ab3b5bce29b883b931ac55507
+ */
+
+#include <iostream>
+#include <ostream>
+#include <istream>
+#include <ctime>
+#include <string>
+#include <functional>
+#include <boost/asio.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/thread.hpp>
+
+using boost::asio::ip::tcp;
+
+class HttpServer; // forward declaration
+
+class Request : public boost::enable_shared_from_this<Request>
+{
+	// member variables
+	HttpServer& server;
+	boost::asio::streambuf request;
+	boost::asio::streambuf response;
+
+	void afterRead(const boost::system::error_code& ec, std::size_t bytes_transferred)
+	{
+		// done reading, writes answer (yes, we ignore the request);
+		std::ostream res_stream(&response);
+
+		boost::system::error_code err;
+		res_stream << "HTTP/1.0 200 OK\r\n"
+			<< "Content-Type: text/html; charset=UTF-8\r\n"
+			<< "Content-Length: 14\r\n"
+			<< "\r\n"
+			<< "Hello, World!\n" << "\r\n";
+		boost::asio::async_write(*socket, response, boost::bind(&Request::afterWrite, shared_from_this(), err, bytes_transferred));
+	}
+
+	void afterWrite(const boost::system::error_code& ec, std::size_t bytes_transferred)
+	{
+		// done writing, closing connection
+		socket->close();
+	}
+
+	public:
+
+	boost::shared_ptr<tcp::socket> socket;
+	Request(HttpServer& server);
+	void answer()
+	{
+		if (!socket) return;
+
+		// reads request till the end
+		boost::system::error_code err;
+		boost::asio::async_read_until(*socket, request, "\r\n\r\n",
+				boost::bind(&Request::afterRead, shared_from_this(), err, 0));
+	}
+};
+
+
+class HttpServer
+{
+	public:
+
+		HttpServer(unsigned int port) : acceptor(io_service, tcp::endpoint(tcp::v4(), port)) {}
+		~HttpServer() { if (sThread) sThread->join(); }
+
+		void Run()
+		{
+			sThread.reset(new boost::thread(boost::bind(&HttpServer::thread_main, this)));
+		}
+
+		boost::asio::io_service io_service;
+
+	private:
+		tcp::acceptor acceptor;
+		boost::shared_ptr<boost::thread> sThread;
+
+		void thread_main()
+		{
+			// adds some work to the io_service
+			start_accept();
+			io_service.run();
+		}
+		void start_accept()
+		{
+			boost::system::error_code err;
+			boost::shared_ptr<Request> req (new Request(*this));
+			acceptor.async_accept(*req->socket,
+					boost::bind(&HttpServer::handle_accept, this, req, err));
+		}
+
+		void handle_accept(boost::shared_ptr<Request> req, const boost::system::error_code& error)
+		{
+			if (!error) { req->answer(); }
+			start_accept();
+		}
+};
+
+Request::Request(HttpServer& server): server(server)
+{
+	socket.reset(new tcp::socket(server.io_service));
+}
+
+
+int main()
+{
+	HttpServer server(8080);
+	server.Run();
+}


### PR DESCRIPTION
Introduce an HTTP C++ Boost server as binary compatibility run. Build server as static PIE application using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.cpp`: the C++ Boost HTTP server

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.