### PR TITLE
feat(examples): Introduce HTTP Ruby server as example

### DIFF
--- a/examples/http-ruby3.2/.gitignore
+++ b/examples/http-ruby3.2/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-ruby3.2/Dockerfile
+++ b/examples/http-ruby3.2/Dockerfile
@@ -1,0 +1,23 @@
+FROM --platform=linux/x86_64 ruby:3.2.2-bookworm AS build
+
+FROM scratch
+
+# Ruby binary
+COPY --from=build /usr/local/bin/ruby /usr/local/bin/ruby
+
+# Ruby libraries
+COPY --from=build /usr/local/lib/ruby /usr/local/lib/ruby
+
+# System libraries
+COPY --from=build /usr/local/lib/libruby.so.3.2 /usr/local/lib/libruby.so.3.2
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libgmp.so.10 /lib/x86_64-linux-gnu/libgmp.so.10
+COPY --from=build /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# Simple Ruby HTTP server
+COPY ./http_server.rb /http_server.rb

--- a/examples/http-ruby3.2/Kraftfile
+++ b/examples/http-ruby3.2/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-ruby
+
+runtime: index.unikraft.io/official/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/ruby", "/http_server.rb"]

--- a/examples/http-ruby3.2/Makefile
+++ b/examples/http-ruby3.2/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-ruby
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-ruby3.2/README.md
+++ b/examples/http-ruby3.2/README.md
@@ -1,0 +1,49 @@
+# Simple Ruby HTTP Web Server
+
+This directory contains a simple HTTP server written in JavaScript for [Ruby](https://www.ruby-lang.org/en/) running with Unikraft in binary compatibility mode.
+The image opens up a simple HTTP server and provides a simple HTML response for each request.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+**Note**: This currently doesn't work, it fails with:
+
+```text
+mprotect(va:0x1000035000, 4096, PROT_READ) = OK
+openat(AT_FDCWD, "/http_server.rb", O_RDONLY|O_CLOEXEC|O_NONBLOCK) = fd:5
+fcntl(0x5, 0x4, ...) = Invalid argument (-22)
+close(fd:5) = OK
+ioctl(0x2, 0x5401, ...) = 0x0
+ruby: write(fd:2, "ruby: ", 6) = 6
+Invalid argument -- /http_server.rb (LoadError)write(fd:2, "\x1B[1mInvalid argument -- "..., 67) = 67
+write(fd:2, "\x0A", 1) = 1
+rt_sigaction(0x2, 0x408ddf950, ...) = 0x0
+getpid() = pid:1
+getpid() = pid:1
+```
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 256M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-ruby3.2/config.yaml
+++ b/examples/http-ruby3.2/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 256

--- a/examples/http-ruby3.2/http_server.rb
+++ b/examples/http-ruby3.2/http_server.rb
@@ -1,0 +1,20 @@
+# https://dev.to/leandronsp/web-basics-a-simple-http-server-in-ruby-2jj4
+
+require 'socket'
+
+socket = TCPServer.new(8080)
+
+loop do
+  client = socket.accept
+
+  request = client.gets
+
+  response = "HTTP/1.1 200 OK\r\n" \
+    "Content-type: text/html\r\n" \
+    "Connection: close\r\n" \
+    "\r\n" \
+    "Hello, World!"
+  client.puts(response)
+
+  client.close
+end


### PR DESCRIPTION
Introduce an HTTP Ruby server as binary compatibility run. Install Ruby using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application
* `http_server.rb`: HTTP server implementation in Ruby

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.