### PR TITLE
feat(examples): Introduce Node Prisma as example

### DIFF
--- a/examples/http-node18-prisma/.gitignore
+++ b/examples/http-node18-prisma/.gitignore
@@ -1,0 +1,6 @@
+/rootfs/
+/rootfs.cpio
+/run-qemu*
+/run-fc*
+/kraft-run-*
+/fc*.json

--- a/examples/http-node18-prisma/Dockerfile
+++ b/examples/http-node18-prisma/Dockerfile
@@ -1,0 +1,58 @@
+FROM --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe; \
+    apt -yqq update; \
+    apt -yqq install \
+        git \
+        nodejs \
+        npm \
+    ;
+
+RUN mkdir /src
+WORKDIR /src
+
+RUN set -xe; \
+    git clone https://github.com/prisma/prisma-examples --depth=1; \
+    cd prisma-examples/javascript/rest-express; \
+    npm install; \
+    npx prisma migrate dev --name init \
+    ;
+
+FROM scratch
+
+# Node binary
+COPY --from=build /usr/bin/node /usr/local/bin/node
+
+# Node files
+COPY --from=build /usr/share/nodejs /usr/share/nodejs
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libnode.so.108 /lib/x86_64-linux-gnu/libnode.so.108
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libuv.so.1 /lib/x86_64-linux-gnu/libuv.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlidec.so.1 /lib/x86_64-linux-gnu/libbrotlidec.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlienc.so.1 /lib/x86_64-linux-gnu/libbrotlienc.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libcares.so.2 /lib/x86_64-linux-gnu/libcares.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libnghttp2.so.14 /lib/x86_64-linux-gnu/libnghttp2.so.14
+COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libicui18n.so.72 /lib/x86_64-linux-gnu/libicui18n.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libicuuc.so.72 /lib/x86_64-linux-gnu/libicuuc.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlicommon.so.1 /lib/x86_64-linux-gnu/libbrotlicommon.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libicudata.so.72 /lib/x86_64-linux-gnu/libicudata.so.72
+COPY --from=build /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# Distro definition
+COPY --from=build /etc/os-release /etc/os-release
+COPY --from=build /usr/lib/os-release /usr/lib/os-release
+
+# rest-express + Prisma
+COPY --from=build /src/prisma-examples/javascript/rest-express /rest-express

--- a/examples/http-node18-prisma/Kraftfile
+++ b/examples/http-node18-prisma/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: http-node
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/node", "/rest-express/src/index.js"]

--- a/examples/http-node18-prisma/Makefile
+++ b/examples/http-node18-prisma/Makefile
@@ -1,0 +1,3 @@
+IMAGE_NAME = unikraft-node-prisma
+
+include ../../utils/bincompat/docker.Makefile

--- a/examples/http-node18-prisma/README.md
+++ b/examples/http-node18-prisma/README.md
@@ -1,0 +1,33 @@
+# Node Prisma Example
+
+This directory contains a simple [Prisma](https://www.prisma.io/) example (using avaScript for [Node](https://nodejs.org/en/)) running with Unikraft in binary compatibility mode.
+The image opens up a server and provides routes for results.
+
+Follow the instructions in the common `../README.md` file to set up and configure the application.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 512M -p 8080:8080
+```
+
+Once executed, it will open port `8080` and wait for connections, and can be queried.
+
+Query the service using:
+
+```console
+curl localhost:8080
+```
+
+It will print a "Hello, World!" message.
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Once you run the the scripts, query the service:
+
+```console
+curl 172.44.0.2:8080
+```

--- a/examples/http-node18-prisma/config.yaml
+++ b/examples/http-node18-prisma/config.yaml
@@ -1,0 +1,3 @@
+networking: True
+accel: True
+memory: 1024


### PR DESCRIPTION
Introduce a Node Prisma example as binary compatibility run. Install Node and Prism using `Dockerfile`. Then run it with the `base` kernel images from `../../kernels/`.

Add typical files for a bincompat app:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `Makefile`: used to generate the root filesystem from the `Dockerfile` rules
* `README.md`: instructions to set up, build and run the application
* `config.yaml`: configuration file to generate scripts to the application

`config.yaml` is used to generate run scripts using the `../../utils/bincompat/generate.py` script.

The kernels in `../../kernels` are generated by running the `../../utils/bincompat/base-build-all.sh` script while inside the `../../library/base/` directory.