### PR TITLE
utils: Use return in sourced script

### DIFF
--- a/utils/start-buildkit.sh
+++ b/utils/start-buildkit.sh
@@ -19,7 +19,7 @@ if test $? -eq 0; then
 else
     echo "Installing 'buildkitd' container ... "
     docker run -d --name buildkitd --privileged moby/buildkit:latest
-    exit $?
+    return $?
 fi
 
 test "$(docker container inspect -f '{{.State.Running}}' buildkitd 2> /dev/null)" = "true"
@@ -28,5 +28,5 @@ if test $? -eq 0; then
 else
     echo "Starting 'buildkitd' container ... "
     docker start buildkitd
-    exit $?
+    return $?
 fi


### PR DESCRIPTION
The `utils/start-buildkit.sh` script is to be sourced. As such it cannot use the `exit` command, because that will close the current shell. Replace `exit` with `return` command.